### PR TITLE
Progress Bar Update

### DIFF
--- a/src/Rank.js
+++ b/src/Rank.js
@@ -47,6 +47,9 @@ const assets = require("./Assets");
  * @property {string} [level.textColor="#FFFFFF"] color de texto de nivel
  * @property {string} [level.color="#F3F3F3"] color de nivel
  * @property {string} [level.displayText="LEVEL"] texto de visualización de nivel
+ * @property {object} previousRankXP tarjeta xp de rango anterior opcional
+ * @property {number} [previousRankXP.data=null] xp de rango anterior opcional
+ * @property {string} [previousRankXP.color=null] Tabla de rango de color de rango xp anterior opcional
  * @property {object} currentXP Tarjeta de rango xp actual
  * @property {number} [currentXP.data=0] XP actual
  * @property {string} [currentXP.color="#FFFFFF"] Carta de rango color xp actual
@@ -139,6 +142,10 @@ class Rank {
         textColor: "#FFFFFF",
         color: "#F3F3F3",
         displayText: "LEVEL"
+      },
+      previousRankXP: {
+        data: null,
+        color: null,
       },
       currentXP: {
         data: 0,
@@ -341,6 +348,19 @@ class Rank {
     this.data.overlay.color = color;
     this.data.overlay.display = !!display;
     this.data.overlay.level = level && typeof level === "number" ? level : 0.5;
+    return this;
+  }
+
+  /**
+   * Establecer XP de rango anterior
+   * @param {number} data XP actual
+   * @param {string} color Color
+   * @returns {Rank}
+   */
+  setPreviousRankXP(data, color = "#FFFFFF") {
+    if (typeof data !== "number") throw new Error(`El tipo de datos XP de rango anterior debe ser un número, recibido ${typeof data}!`);
+    this.data.previousRankXP.data = data;
+    this.data.previousRankXP.color = color && typeof color === "string" ? color : "#FFFFFF";
     return this;
   }
 
@@ -710,17 +730,23 @@ class Rank {
    * @ignore
    */
   get _calculateProgress() {
+    const px = this.data.previousRankXP.data;
     const cx = this.data.currentXP.data;
     const rx = this.data.requiredXP.data;
 
     if (rx <= 0) return 1;
     if (cx > rx) return this.data.progressBar.width;
 
-    let width = (cx * 615) / rx;
-    if (width > this.data.progressBar.width) width = this.data.progressBar.width;
-    return width;
+    if (!px || px > cx) {
+      let width = (cx * 615) / rx;
+      if (width > this.data.progressBar.width) width = this.data.progressBar.width;
+      return width;
+    } else {
+      let width = ((cx - px) * 615) / (rx - px);
+      if (width > this.data.progressBar.width) width = this.data.progressBar.width;
+      return width;
+    }
   }
-
 }
 
 module.exports = Rank;


### PR DESCRIPTION
Traducido al español (lo mejor posible):
Actualice para permitir que la barra de progreso sea mucho más precisa:

`setPreviousXP()` hecho como entrada opcional para el rango anterior XP.
- Ayuda a calcular la barra de progreso de forma más precisa.
- Restablecer la barra de progreso, incluso con XP muy alta.
- Escala la barra de XP para mostrar la progresión correctamente.

`get _calculateProgress(){` actualizado para verificar el rango anterior XP.
- Si no se proporciona XP de rango anterior, use el método predeterminado.
- Si se proporciona XP de rango anterior, use: `width = ((cx - px) * 615) / (rx - px);`

**Antes:**
- El usuario tiene: 24.404 XP.
- XP requerido es: 27,673 XP.
- Barra de progreso: 542.35/615 = 88% de progreso.

**Después:**
- El usuario tiene: 24.404 XP.
- XP requerido es: 27,673 XP.
- El XP de rango anterior es: 24,359 XP.
- Barra de progreso: 8,35/615 = 1,36 % de progreso.

**Imagen:**
- 1er canvacard = antes.
- 2nd canvacard = después.
- 3rd - 5th canvacard muestran que la barra de progreso funciona mejor con rangos altos/XP.

![Screenshot 2022-11-21 134853](https://user-images.githubusercontent.com/50148901/203138332-73c3792d-5445-4008-8c3b-c18d35d3805a.png)

**Imagen 2:**
- Muestra un nivel alto y la barra de progreso de XP es más precisa.
- Muestra un nivel alto y la barra de progreso de XP se restablece a un % de progreso bajo.

![Screenshot 2022-11-21 141643](https://user-images.githubusercontent.com/50148901/203140578-0ad8ea84-8ca2-4195-bbfb-0ed30cac0b94.png)

English:

Update to allow progress bar to be much more accurate:

`setPreviousXP()` made as optional input for previous rank XP.
- Helps calculate progress bar more accurate.
- Reset's progress bar, even at very high XP.
- Scales the XP bar to show progression correctly.

`get _calculateProgress(){` updated to check for previous rank XP.
- If no previous rank XP is provided, use default method.
- If previous rank XP is provided, use: `width = ((cx - px) * 615) / (rx - px);`

**Before:**
- User has: 24,404 XP.
- Required XP is: 27,673 XP.
- Progress bar: 542.35/615 = 88% progress.

**After:**
- User has: 24,404 XP.
- Required XP is: 27,673 XP.
- Previous Rank XP is: 24,359 XP.
- Progress bar: 8.35/615 = 1.36% progress.

**Picture:**
- 1st canvacard = before.
- 2nd canvacard = after.
- 3rd - 5th canvacard show the progress bar working better with high ranks/XP.

![Screenshot 2022-11-21 134853](https://user-images.githubusercontent.com/50148901/203138332-73c3792d-5445-4008-8c3b-c18d35d3805a.png)

**Picture 2:**
- Shows high level and XP progress bar being more accurate.
- Shows high level and XP progress bar being reset to low progress %.

![Screenshot 2022-11-21 141643](https://user-images.githubusercontent.com/50148901/203140578-0ad8ea84-8ca2-4195-bbfb-0ed30cac0b94.png)